### PR TITLE
Add spatial ensemble

### DIFF
--- a/get_iterative_source_field.m
+++ b/get_iterative_source_field.m
@@ -22,9 +22,15 @@ end
 gx_source = JOBFILE.Processing(PASS_NUMBER).Grid.Points.Full.X;
 gy_source = JOBFILE.Processing(PASS_NUMBER).Grid.Points.Full.Y;
 
+% Number of grid points
+num_grid_points = length(gx_source);
+
+% Get the number of pairs
+num_pairs_correlate = read_num_pairs(JOBFILE, PASS_NUMBER);
+
 % Set the source field to zeros
-tx_source = zeros(size(gx_source));
-ty_source = zeros(size(gy_source));
+tx_source = zeros(num_grid_points, num_pairs_correlate);
+ty_source = zeros(num_grid_points, num_pairs_correlate);
 
 % Check if the iterative field exists in the jobfile
 if isfield(JOBFILE.Processing(PASS_NUMBER), 'Iterative');

--- a/get_iterative_source_field.m
+++ b/get_iterative_source_field.m
@@ -56,8 +56,10 @@ if isfield(JOBFILE.Processing(PASS_NUMBER), 'Iterative');
             % Read the final output displacement
             % field from the previous pass.
             if isfield(previous_pass_struct, 'Results')
-                tx_source = previous_pass_struct.Results.Displacement.Final.X;
-                ty_source = previous_pass_struct.Results.Displacement.Final.Y;        
+                tx_source = previous_pass_struct.Results. ...
+                    Displacement.Final.X;
+                ty_source = previous_pass_struct.Results. ...
+                    Displacement.Final.Y;        
             end            
         end
 
@@ -65,14 +67,16 @@ if isfield(JOBFILE.Processing(PASS_NUMBER), 'Iterative');
         if isfield(JOBFILE.Processing(PASS_NUMBER).Iterative, 'Source')
 
             % IF the "source" field exists, extract it.
-            iterative_source_field = JOBFILE.Processing(PASS_NUMBER).Iterative.Source;
+            iterative_source_field = JOBFILE.Processing(PASS_NUMBER). ...
+                Iterative.Source;
 
             % Check whether the fields for the directory
             % and name of the source files exist.
             if isfield(iterative_source_field, 'Directory')
                 % Read the name of the directory that
                 % is supposed to contain the source file.
-                velocity_source_file_dir = JOBFILE.Processing(PASS_NUMBER).Iterative.Source.Directory;
+                velocity_source_file_dir = JOBFILE. ...
+                    Processing(PASS_NUMBER).Iterative.Source.Directory;
             else
                 % Default to an empty string
                 velocity_source_file_dir = '';
@@ -82,7 +86,8 @@ if isfield(JOBFILE.Processing(PASS_NUMBER), 'Iterative');
             if isfield(iterative_source_field, 'Name')
                 % Read the name of the file that is 
                 % supposed to contain the source data.
-                velocity_source_file_name = JOBFILE.Processing(PASS_NUMBER).Iterative.Source.Name;
+                velocity_source_file_name = JOBFILE. ...
+                    Processing(PASS_NUMBER).Iterative.Source.Name;
             else
                 % Default to an empty string
                 velocity_source_file_name = '';

--- a/jobfiles/PIVJobList_pivchallenge.m
+++ b/jobfiles/PIVJobList_pivchallenge.m
@@ -1,13 +1,13 @@
 function JOBLIST = PIVJobList_pivchallenge()
 
 % Number of passes to run
-num_passes_spec = 3;
+num_passes_spec = 2;
 
 % % Pass parameters
 region_height_list_raw = [64,  64,  64, 32, 32, 32];
 region_width_list_raw  = [128, 128, 64, 32, 32, 32];
 window_fract_list_raw = {[0.5, 0.5; 0.5, 1], 0.5, 0.5, 1.0, 24/32, 24/32};
-grid_spacing_list_raw = [64, 64, 64, 16, 16, 2];
+grid_spacing_list_raw = [128, 128, 64, 16, 16, 2];
 grid_spacing_list_raw_x = grid_spacing_list_raw;
 grid_spacing_list_raw_y = grid_spacing_list_raw;
 
@@ -70,16 +70,16 @@ Processing(1).Grid.Mask.Name = 'imgAmask3.tif';
 
 % Frame parameters.
 Processing(1).Frames.Start = 1;
-Processing(1).Frames.End = 5;
+Processing(1).Frames.End = 10;
 Processing(1).Frames.Step = 1;
 
 % Correlation parameters
-Processing(1).Correlation.Method = 'scc';
+Processing(1).Correlation.Method = 'apc';
 Processing(1).Correlation.Step = 0;
 % Processing(1).Correlation.Step = 1;
-Processing(1).Correlation.Ensemble.DoEnsemble = 1;
+Processing(1).Correlation.Ensemble.DoEnsemble = 0;
 Processing(1).Correlation.Ensemble.NumberOfPairs = 1;
-Processing(1).Correlation.Ensemble.Domain = 'spatial';
+Processing(1).Correlation.Ensemble.Domain = 'spectral';
 Processing(1).Correlation.Ensemble.Direction = 'temporal';
 
 % Parameters specific to APC

--- a/jobfiles/PIVJobList_pivchallenge.m
+++ b/jobfiles/PIVJobList_pivchallenge.m
@@ -1,13 +1,13 @@
-function JOBLIST = PIVJobList_default()
+function JOBLIST = PIVJobList_pivchallenge()
 
 % Number of passes to run
-num_passes_spec = 5;
+num_passes_spec = 3;
 
 % % Pass parameters
 region_height_list_raw = [64,  64,  64, 32, 32, 32];
 region_width_list_raw  = [128, 128, 64, 32, 32, 32];
 window_fract_list_raw = {[0.5, 0.5; 0.5, 1], 0.5, 0.5, 1.0, 24/32, 24/32};
-grid_spacing_list_raw = [64, 64, 32, 16, 16, 2];
+grid_spacing_list_raw = [64, 64, 64, 16, 16, 2];
 grid_spacing_list_raw_x = grid_spacing_list_raw;
 grid_spacing_list_raw_y = grid_spacing_list_raw;
 
@@ -41,7 +41,7 @@ Data.Inputs.Vectors.Digits = 5;
 Data.Inputs.Vectors.Extension = '.mat';
 
 % Data: output vectors
-Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect';
+Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect/test';
 Data.Outputs.Vectors.BaseName = 'A_deghost_';
 Data.Outputs.Vectors.Digits = 5;
 Data.Outputs.Vectors.Extension = '.mat';
@@ -70,7 +70,7 @@ Processing(1).Grid.Mask.Name = 'imgAmask3.tif';
 
 % Frame parameters.
 Processing(1).Frames.Start = 1;
-Processing(1).Frames.End = 1;
+Processing(1).Frames.End = 5;
 Processing(1).Frames.Step = 1;
 
 % Correlation parameters
@@ -80,7 +80,7 @@ Processing(1).Correlation.Step = 0;
 Processing(1).Correlation.Ensemble.DoEnsemble = 1;
 Processing(1).Correlation.Ensemble.NumberOfPairs = 1;
 Processing(1).Correlation.Ensemble.Domain = 'spatial';
-Processing(1).Correlation.Ensemble.Direction = 3;
+Processing(1).Correlation.Ensemble.Direction = 'temporal';
 
 % Parameters specific to APC
 Processing(1).Correlation.APC.FilterDiameterUpperBound = 6;

--- a/jobfiles/PIVJobList_pivchallenge_2003B.m
+++ b/jobfiles/PIVJobList_pivchallenge_2003B.m
@@ -1,13 +1,13 @@
-function JOBLIST = PIVJobList_synthetic()
+function JOBLIST = PIVJobList_pivchallenge_2003B()
 
 % Number of passes to run
-num_passes_spec = 2;
+num_passes_spec = 1;
 
 % % Pass parameters
-region_height_list_raw = [128, 64];
-region_width_list_raw = [128, 64];
+region_height_list_raw = [32, 64];
+region_width_list_raw  = [32, 64];
 window_fract_list_raw = {0.5, 0.5};
-grid_spacing_list_raw = [64, 64];
+grid_spacing_list_raw = [8, 32];
 grid_spacing_list_raw_x = grid_spacing_list_raw;
 grid_spacing_list_raw_y = grid_spacing_list_raw;
 
@@ -25,13 +25,12 @@ num_passes_total = length(region_height_list);
 JobOptions.NumberOfPasses = 0;
 
 % Data: Input images
-% Data.Inputs.Images.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/images/proc/ghost';
-Data.Inputs.Images.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/poiseuille_diffusion_0.00/raw';
-% Data.Inputs.Images.BaseName = 'A_deghost_';
-Data.Inputs.Images.BaseName = 'poiseuille_diffusion_0.00_';
-Data.Inputs.Images.Digits = 5;
-Data.Inputs.Images.Extension = '.tif';
-% Data.Inputs.Images.Trailers = {'_a', '_b'};
+Data.Inputs.Images.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2003/piv_challenge_2003_B/raw';
+Data.Inputs.Images.BaseName = 'B';
+% Data.Inputs.Images.BaseName = 'poiseuille_diffusion_0.00_';
+Data.Inputs.Images.Digits = 3;
+Data.Inputs.Images.Extension = '.bmp';
+Data.Inputs.Images.Trailers = {'a', 'b'};
 % Data.Inputs.Images.Trailers = {''};
 
 % Data: Input vectors for initializing, e.g., image deformation.
@@ -41,18 +40,19 @@ Data.Inputs.Vectors.Digits = 5;
 Data.Inputs.Vectors.Extension = '.mat';
 
 % Data: output vectors
-% Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect';
-Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/poiseuille_diffusion_0.00/raw';
-Data.Outputs.Vectors.BaseName = 'poiseuille_diffusion_0.00_';
-Data.Outputs.Vectors.Digits = 5;
+Data.Outputs.Vectors.Directory = fullfile(Data.Inputs.Images.Directory, '..', 'vect');
+Data.Outputs.Vectors.BaseName = 'B_';
+Data.Outputs.Vectors.Digits = 3;
 Data.Outputs.Vectors.Extension = '.mat';
 
 % Interrogation region dimensions
-Processing(1).Region.Height = 128;
+Processing(1).Region.Height = 64;
 Processing(1).Region.Width = 128;
+% Processing(1).Region.Height = 128;
+% Processing(1).Region.Width = 128;
 
 % Spatial window
-Processing(1).Window.Fraction = 0.5;
+Processing(1).Window.Fraction = [0.5, 0.5; 0.5, 1];
 
 % Grid parameters
 Processing(1).Grid.Spacing.Y = 64;
@@ -69,20 +69,20 @@ Processing(1).Grid.Mask.Name = '';
 
 % Frame parameters.
 Processing(1).Frames.Start = 1;
-Processing(1).Frames.End = 19;
+Processing(1).Frames.End = 100;
 Processing(1).Frames.Step = 1;
 
 % Correlation parameters
 Processing(1).Correlation.Method = 'apc';
-% Processing(1).Correlation.Step = 0;
-Processing(1).Correlation.Step = 1;
-Processing(1).Correlation.Ensemble.DoEnsemble = 1;
+Processing(1).Correlation.Step = 0;
+% Processing(1).Correlation.Step = 1;
+Processing(1).Correlation.Ensemble.DoEnsemble = 0;
 Processing(1).Correlation.Ensemble.NumberOfPairs = 1;
 Processing(1).Correlation.Ensemble.Domain = 'spectral';
 Processing(1).Correlation.Ensemble.Direction = 'temporal';
 
 % Parameters specific to APC
-Processing(1).Correlation.APC.FilterDiameterUpperBound = 3;
+Processing(1).Correlation.APC.FilterDiameterUpperBound = 1;
 Processing(1).Correlation.APC.Shuffle.Range = [0, 0];
 Processing(1).Correlation.APC.Shuffle.Step = [0, 0];
 Processing(1).Correlation.APC.Method = 'magnitude';

--- a/jobfiles/PIVJobList_pivchallenge_2003B.m
+++ b/jobfiles/PIVJobList_pivchallenge_2003B.m
@@ -7,7 +7,7 @@ num_passes_spec = 1;
 region_height_list_raw = [32, 64];
 region_width_list_raw  = [32, 64];
 window_fract_list_raw = {0.5, 0.5};
-grid_spacing_list_raw = [8, 32];
+grid_spacing_list_raw = [16, 32];
 grid_spacing_list_raw_x = grid_spacing_list_raw;
 grid_spacing_list_raw_y = grid_spacing_list_raw;
 

--- a/jobfiles/PIVJobList_synthetic.m
+++ b/jobfiles/PIVJobList_synthetic.m
@@ -1,6 +1,27 @@
 function JOBLIST = PIVJobList_synthetic()
 
+% Number of passes to run
+num_passes_spec = 2;
+
+% % Pass parameters
+region_height_list_raw = [128, 64];
+region_width_list_raw = [128, 64];
+window_fract_list_raw = {0.5, 0.5};
+grid_spacing_list_raw = [64, 64];
+grid_spacing_list_raw_x = grid_spacing_list_raw;
+grid_spacing_list_raw_y = grid_spacing_list_raw;
+
+region_height_list = region_height_list_raw(1 : num_passes_spec);
+region_width_list = region_width_list_raw(1 : num_passes_spec);
+window_fract_list = window_fract_list_raw(1 : num_passes_spec);
+grid_spacing_list_x = grid_spacing_list_raw_x(1 : num_passes_spec);
+grid_spacing_list_y = grid_spacing_list_raw_y(1 : num_passes_spec);
+
+% Total number of passes
+num_passes_total = length(region_height_list);
+
 % Number of passes
+% zero means run all of them.
 JobOptions.NumberOfPasses = 0;
 
 % Data: Input images
@@ -11,7 +32,7 @@ Data.Inputs.Images.BaseName = 'poiseuille_diffusion_0.00_';
 Data.Inputs.Images.Digits = 5;
 Data.Inputs.Images.Extension = '.tif';
 % Data.Inputs.Images.Trailers = {'_a', '_b'};
-Data.Inputs.Images.Trailers = {''};
+% Data.Inputs.Images.Trailers = {''};
 
 % Data: Input vectors for initializing, e.g., image deformation.
 Data.Inputs.Vectors.Directory = '';
@@ -20,63 +41,61 @@ Data.Inputs.Vectors.Digits = 5;
 Data.Inputs.Vectors.Extension = '.mat';
 
 % Data: output vectors
-Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect';
-Data.Outputs.Vectors.BaseName = 'A_deghost_';
+% Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect';
+Data.Outputs.Vectors.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/poiseuille_diffusion_0.00/raw';
+Data.Outputs.Vectors.BaseName = 'poiseuille_diffusion_0.00_';
 Data.Outputs.Vectors.Digits = 5;
 Data.Outputs.Vectors.Extension = '.mat';
 
 % Interrogation region dimensions
-% Processing(1).Region.Height = 64;
-% Processing(1).Region.Width = 128;
 Processing(1).Region.Height = 128;
 Processing(1).Region.Width = 128;
 
 % Spatial window
-% Processing(1).Window.Fraction = {[0.25, 0.5], [0.25, 1]};
-Processing(1).Window.Fraction = {0.5};
+Processing(1).Window.Fraction = 0.5;
 
 % Grid parameters
 Processing(1).Grid.Spacing.Y = 64;
 Processing(1).Grid.Spacing.X = 64;
-% Processing(1).Grid.Shift.Y = -16;
-Processing(1).Grid.Shift.Y = 0;
+Processing(1).Grid.Shift.Y = -16;
 Processing(1).Grid.Shift.X = 0;
 Processing(1).Grid.Buffer.Y = 0;
 Processing(1).Grid.Buffer.X = 0;
-% Processing(1).Grid.Mask.Directory = '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/images/masks';
-% Processing(1).Grid.Mask.Name = 'imgAmask3.tif';
 Processing(1).Grid.Mask.Directory = '';
 Processing(1).Grid.Mask.Name = '';
-
+% Processing(1).Grid.Mask.Name = 'mask_jet_subregion.tif';
+% Processing(1).Grid.Mask.Directory = '';
+% Processing(1).Grid.Mask.Name = '';
 
 % Frame parameters.
 Processing(1).Frames.Start = 1;
-Processing(1).Frames.End = 1;
+Processing(1).Frames.End = 3;
 Processing(1).Frames.Step = 1;
 
 % Correlation parameters
-Processing(1).Correlation.Method = 'rpc';
+Processing(1).Correlation.Method = 'apc';
 % Processing(1).Correlation.Step = 0;
 Processing(1).Correlation.Step = 1;
 Processing(1).Correlation.Ensemble.DoEnsemble = 1;
 Processing(1).Correlation.Ensemble.NumberOfPairs = 1;
 Processing(1).Correlation.Ensemble.Domain = 'spectral';
+Processing(1).Correlation.Ensemble.Direction = 'none';
 
 % Parameters specific to APC
-Processing(1).Correlation.APC.EnsembleLength = 10;
-Processing(1).Correlation.APC.FilterDiameterUpperBound = 6;
+Processing(1).Correlation.APC.FilterDiameterUpperBound = 3;
 Processing(1).Correlation.APC.Shuffle.Range = [0, 0];
 Processing(1).Correlation.APC.Shuffle.Step = [0, 0];
+Processing(1).Correlation.APC.Method = 'magnitude';
 
 % Parameters specific to RPC
-Processing(1).Correlation.RPC.EffectiveDiameter = 6;
+Processing(1).Correlation.RPC.EffectiveDiameter = 3;
 
 % Subpixel fit parameters
 Processing(1).SubPixel.Method = '3-point fit';
-Processing(1).SubPixel.EstimatedParticleDiameter = 6;
+Processing(1).SubPixel.EstimatedParticleDiameter = 3;
 
 % Parameters for vector validation
-Processing(1).Validation.DoValidation = 0;
+Processing(1).Validation.DoValidation = 1;
 Processing(1).Validation.ValidationMethod = 'uod';
 
 % Parameters for smoothing
@@ -92,17 +111,34 @@ Processing(1).Iterative.Deform.MaxIterations = 1;
 Processing(1).Iterative.Source.Directory = '';
 Processing(1).Iterative.Source.Name = '';
 Processing(1).Iterative.Source.PassNumber = 0;
-Processing(1).Iterative.Source.VariableNames.Displacements.X = 'tx_smoothed';
-Processing(1).Iterative.Source.VariableNames.Displacements.Y = 'ty_smoothed';
-Processing(1).Iterative.Source.VariableNames.Grid.X = 'gy';
-Processing(1).Iterative.Source.VariableNames.Grid.Y = 'gx';
 
+% Default Processing
+default_processing = Processing(1);
 
-% Copy the first processing pass to the second one.
-Processing(2) = Processing(1);
-
-Processing(2).Grid.Spacing.Y = 32;
-Processing(2).Grid.Spacing.X = 32;
+% Loop over all the passes
+for p = 1 : num_passes_total
+    
+   % Copy the default pass
+   piv_pass = default_processing; 
+   
+   % Region size
+   piv_pass.Region.Height = region_height_list(p);
+   piv_pass.Region.Width  = region_width_list(p);
+   
+   % Grid buffers
+   piv_pass.Grid.Buffer.X = region_width_list(p)/2;
+   piv_pass.Grid.buffer.Y = region_height_list(p)/2;
+   
+   % Window
+   piv_pass.Window.Fraction = window_fract_list{p};
+   
+   % Grid
+   piv_pass.Grid.Spacing.Y = grid_spacing_list_y(p);
+   piv_pass.Grid.Spacing.X = grid_spacing_list_x(p);
+   
+   % Add to the structure
+   Processing(p) = piv_pass;    
+end
 
 % Add the fields to the jobfile structure.
 JobFile.Data = Data;
@@ -111,6 +147,7 @@ JobFile.JobOptions = JobOptions;
 
 % Append to the job list.
 JOBLIST(1) = JobFile;
+
 
 end
 

--- a/planes2vect.m
+++ b/planes2vect.m
@@ -1,0 +1,164 @@
+function [TY, TX, PARTICLE_DIAMETER_Y, PARTICLE_DIAMETER_X] = planes2vect(JOBFILE, PASS_NUMBER)
+
+% Read the ensemble domain string
+ensemble_domain_string = read_ensemble_domain(JobFJOBFILEile, PASS_NUMBER);
+
+% Read the ensemble direction
+ensemble_direction_string = lower( ...
+    read_ensemble_direction(JOBFILE, PASS_NUMBER));
+
+% Extract the correlation planes from the job file
+cross_corr_ensemble = JOBFILE.Processing(PASS_NUMBER).Correlation.Planes;
+
+% Correlation filter
+correlation_method_string = lower(JOBFILE.Processing(PASS_NUMBER). ...
+    Correlation.Method);
+
+% If the ensemble direction was "spatial,"
+% then add all the planes together
+switch lower(ensemble_direction_string)
+    case 'spatial'
+        % If the spatial correlation was specified,
+        % then add all the correlations together. 
+        cross_corr_ensemble = sum(cross_corr_ensemble, 3);
+end
+
+% Get the number of correlation planes remaining.
+[region_height, region_width, num_correlation_planes] ...
+    = size(cross_corr_ensemble);
+
+% Static particle diameters
+% Particle diameter
+particle_diameter = JOBFILE.Processing(PASS_NUMBER). ...
+    SubPixel.EstimatedParticleDiameter;
+
+% Method specific options
+switch lower(correlation_method_string)
+    case 'rpc'   
+        % Read the RPC diameter
+        rpc_diameter = ...
+            JOBFILE.Processing(PASS_NUMBER). ...
+            Correlation.RPC.EffectiveDiameter;
+        
+        % Particle diameter
+        particle_diameter = rpc_diameter;
+        
+        % Create the RPC filter
+        spectral_filter_static = spectral_energy_filter( ...
+            region_height, region_width, rpc_diameter);
+    case 'gcc'
+    % Create the GCC filter (ones everywhere)
+    spectral_filter_static = ones(region_height, region_width);
+    
+    case 'apc'
+        % Set the upper bound for the filter
+        apc_filter_upper_bound = JOBFILE.Processing(PASS_NUMBER). ...
+            Correlation.APC.FilterDiameterUpperBound;
+    
+end
+
+% Make the list of particle diameters
+% for the static methods
+particle_diameter_list_x = zeros(num_correlation_planes);
+particle_diameter_list_y = zeros(num_correlation_planes);
+
+% Set the diameters
+particle_diameter_list_x(:) = particle_diameter;
+particle_diameter_list_y(:) = particle_diameter;
+
+% If the spectral ensemble was performed,
+% then the spectal ensemble correlations
+% need to be inverse-Fourier transformed
+% back into the spatial domain. 
+% This checks which type of ensemble was run
+% (spatial or spectral) and does the inverse
+% transform if necessary. Note that this transform
+% happens in-place, i.e., the value of 
+% the variable cross_corr_ensemble is changed
+% after this result, rather than the transformed
+% correlations being saved as a separate variable.
+% This is to save memory, and also to reduce
+% the number of variables we have to keep track of.
+switch lower(ensemble_domain_string)
+    case 'spectral'
+        
+        % Inform the user
+        fprintf(1, 'Calculating inverse FTs...\n');
+        % Do the inverse transform for each region.
+        parfor k = 1 : num_correlation_planes
+            
+            % Extract the given region
+            cross_corr_spectral = cross_corr_ensemble(:, :, k);
+            
+            % Spectral correlation phase and magnitude
+            [spectral_corr_phase, spectral_corr_mag] = ...
+                split_complex(cross_corr_spectral);
+            
+            % Switch between correlation methods
+            switch lower(correlation_method)
+                case 'scc'           
+                    spectral_filter_temp = spectral_corr_mag;
+                    
+                case 'apc'       
+                    % Calculate the APC filter
+                    [spectral_filter_temp, filter_std_y, filter_std_x] = ...
+                    calculate_apc_filter(cross_corr_spectral, ...
+                    apc_filter_upper_bound, apc_method);
+                
+                    % Equivalent particle diameter in the columns
+                    % direction, calculated from the APC filter.
+                    particle_diameter_list_x(k) = filter_std_dev_to_particle_diameter(...
+                        filter_std_x, region_width);
+                    
+                    % Equivalent particle diameter in the rows
+                    % direction, calculated from the APC filter.
+                    particle_diameter_list_y(k) = filter_std_dev_to_particle_diameter(...
+                        filter_std_y, region_height);
+                otherwise
+                    spectral_filter_temp = spectral_filter_static;
+            end
+            
+            % Apply the phase filter to the spectral plane.
+            % Note that this operation is legitimate even
+            % if SCC or GCC is selected. The reason for this
+            % is that if SCC is selected, then the "filter"
+            % is just the original magnitude. 
+            % I (Matt Giarra) have coded it this way to
+            % simplify the control flow. Not sure if this will
+            % turn out to be a nice way to do it.
+            cross_corr_spectral_filtered = ...
+            spectral_filter_temp .* spectral_corr_phase;
+                
+            % Take the inverse FT of the "filtered" correlation.
+            cross_corr_ensemble(:, :, k) = fftshift(abs(ifft2(fftshift(...
+                        cross_corr_spectral_filtered))));                    
+        end  
+end
+
+% Save the particle diameters
+PARTICLE_DIAMETER_Y = particle_diameter_list_y;
+PARTICLE_DIAMETER_X = particle_diameter_list_x;
+
+% Allocate arrays to hold vectors
+TX = nan(num_correlation_planes, 1);
+TY = nan(num_correlation_planes, 1);
+
+% Allocate the subpixel weights
+sub_pixel_weights = ones(region_height, region_width);
+
+% After adding all the pairs to the ensemble
+% do the subpixel peak detection.
+for k = 1 : num_correlation_planes
+    
+    % Effective particle diameters
+    dp_x = particle_diameter_list_x(k);
+    dp_y = particle_diameter_list_y(k);
+      
+    % Do the subpixel displacement estimate.
+    [TX(k), TY(k)] = ...
+        subpixel(cross_corr_ensemble(:, :, k),...
+            region_width, region_height, sub_pixel_weights, ...
+                1, 0, [dp_x, dp_y]);               
+end
+
+end

--- a/planes2vect.m
+++ b/planes2vect.m
@@ -1,7 +1,7 @@
 function [TY, TX, PARTICLE_DIAMETER_Y, PARTICLE_DIAMETER_X] = planes2vect(JOBFILE, PASS_NUMBER)
 
 % Read the ensemble domain string
-ensemble_domain_string = read_ensemble_domain(JobFJOBFILEile, PASS_NUMBER);
+ensemble_domain_string = read_ensemble_domain(JOBFILE, PASS_NUMBER);
 
 % Read the ensemble direction
 ensemble_direction_string = lower( ...
@@ -85,7 +85,7 @@ switch lower(ensemble_domain_string)
         % Inform the user
         fprintf(1, 'Calculating inverse FTs...\n');
         % Do the inverse transform for each region.
-        parfor k = 1 : num_correlation_planes
+        for k = 1 : num_correlation_planes
             
             % Extract the given region
             cross_corr_spectral = cross_corr_ensemble(:, :, k);
@@ -95,11 +95,15 @@ switch lower(ensemble_domain_string)
                 split_complex(cross_corr_spectral);
             
             % Switch between correlation methods
-            switch lower(correlation_method)
+            switch lower(correlation_method_string)
                 case 'scc'           
                     spectral_filter_temp = spectral_corr_mag;
                     
-                case 'apc'       
+                case 'apc'  
+                    
+                    % Read the APC method
+                    apc_method = JOBFILE.Processing(PASS_NUMBER).Correlation.APC.Method;
+                    
                     % Calculate the APC filter
                     [spectral_filter_temp, filter_std_y, filter_std_x] = ...
                     calculate_apc_filter(cross_corr_spectral, ...

--- a/planes2vect.m
+++ b/planes2vect.m
@@ -59,8 +59,8 @@ end
 
 % Make the list of particle diameters
 % for the static methods
-particle_diameter_list_x = zeros(num_correlation_planes);
-particle_diameter_list_y = zeros(num_correlation_planes);
+particle_diameter_list_x = zeros(num_correlation_planes, 1);
+particle_diameter_list_y = zeros(num_correlation_planes, 1);
 
 % Set the diameters
 particle_diameter_list_x(:) = particle_diameter;
@@ -162,7 +162,13 @@ for k = 1 : num_correlation_planes
     [TX(k), TY(k)] = ...
         subpixel(cross_corr_ensemble(:, :, k),...
             region_width, region_height, sub_pixel_weights, ...
-                1, 0, [dp_x, dp_y]);               
+                1, 0, [dp_x, dp_y]);
+            
 end
 
+
+% Add APC diameters to structure if APC is being done.
+
 end
+
+

--- a/plotting/plot_time_resolved_fields.m
+++ b/plotting/plot_time_resolved_fields.m
@@ -1,7 +1,7 @@
+function plot_time_resolved_fields(JOBFILE)
 
-% Specify results path
-results_path = ...
-    '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect/test/A_deghost_00001_00005.mat';
+% Results path 
+results_path = determine_jobfile_save_path(JOBFILE);
 
 % Load the results
 load(results_path);
@@ -25,6 +25,12 @@ skip_y = 1;
 % Measure the image size
 [image_height, image_width] = read_image_size(JobFile);
 
+temporal_ensemble = ~isempty(regexpi(JobFile(1).Processing.Correlation.Ensemble.Direction, 'tem'));
+
+if temporal_ensemble
+    num_pairs = 1;
+end
+
 % Loop over all the data
 for n = 1 : num_pairs
     
@@ -36,6 +42,9 @@ for n = 1 : num_pairs
         tx = JobFile.Processing(p).Results.Displacement.Raw.X(:, n);
         ty = JobFile.Processing(p).Results.Displacement.Raw.Y(:, n);
         
+        dp_x = JobFile.Processing(p).Results.Filtering.APC.Diameter.X(:, n);
+        dp_y = JobFile.Processing(p).Results.Filtering.APC.Diameter.Y(:, n);
+        
         % Reshapes
         nx = length(unique(gx));
         ny = length(unique(gy));
@@ -43,21 +52,37 @@ for n = 1 : num_pairs
         gy_mat = reshape(gy, [ny, nx]);
         tx_mat = reshape(tx, [ny, nx]);
         ty_mat = reshape(ty, [ny, nx]);
+        dp_x_mat = reshape(dp_x, [ny, nx]);
+        dp_y_mat = reshape(dp_y, [ny, nx]);
+        
+        % Averages
+        dp_x_mean = mean(dp_x_mat, 2);
+        dp_y_mean = mean(dp_y_mat, 2);
+        tx_mean = mean(tx_mat, 2);
+        ty_mean = mean(ty_mat, 2);
+        
   
         % Make the plot
         subtightplot(1, num_passes, p);
+        imagesc(gx_mat(:), gy_mat(:), dp_x_mat);
+        hold on;
         quiver(gx_mat(1 : skip_y : end, 1 : skip_x : end), ...
                gy_mat(1 : skip_y : end, 1 : skip_x : end), ...
                vector_scale * tx_mat(1 : skip_y : end, 1 : skip_x : end), ...
                vector_scale * ty_mat(1 : skip_y : end, 1 : skip_x : end), ...
-               0, 'black');
-           axis image;
+               0, 'white');
            
+       hold off
+        axis image; 
         xlim([1, image_width]);
         ylim([1, image_height]);
     end
   
-    pause(0.5);
+    drawnow;
     
+end
+
+
+
 end
 

--- a/plotting/plot_time_resolved_fields.m
+++ b/plotting/plot_time_resolved_fields.m
@@ -1,0 +1,63 @@
+
+% Specify results path
+results_path = ...
+    '/Users/matthewgiarra/Documents/School/VT/Research/Aether/piv_test_images/pivchallenge/2014/A/vect/test/A_deghost_00001_00005.mat';
+
+% Load the results
+load(results_path);
+
+% Choose the pass
+pass_number = 1;
+
+% Count the number of fields
+num_pairs = read_num_pairs(JobFile);
+
+% number of passes
+num_passes = determine_number_of_passes(JobFile);
+
+% Vector scale
+vector_scale = 3;
+
+% Skips
+skip_x = 1;
+skip_y = 1;
+
+% Measure the image size
+[image_height, image_width] = read_image_size(JobFile);
+
+% Loop over all the data
+for n = 1 : num_pairs
+    
+    for p = 1 : num_passes
+       
+        gx = JobFile.Processing(p).Grid.Points.Full.X;
+        gy = JobFile.Processing(p).Grid.Points.Full.Y;
+        
+        tx = JobFile.Processing(p).Results.Displacement.Raw.X(:, n);
+        ty = JobFile.Processing(p).Results.Displacement.Raw.Y(:, n);
+        
+        % Reshapes
+        nx = length(unique(gx));
+        ny = length(unique(gy));
+        gx_mat = reshape(gx, [ny, nx]);
+        gy_mat = reshape(gy, [ny, nx]);
+        tx_mat = reshape(tx, [ny, nx]);
+        ty_mat = reshape(ty, [ny, nx]);
+  
+        % Make the plot
+        subtightplot(1, num_passes, p);
+        quiver(gx_mat(1 : skip_y : end, 1 : skip_x : end), ...
+               gy_mat(1 : skip_y : end, 1 : skip_x : end), ...
+               vector_scale * tx_mat(1 : skip_y : end, 1 : skip_x : end), ...
+               vector_scale * ty_mat(1 : skip_y : end, 1 : skip_x : end), ...
+               0, 'black');
+           axis image;
+           
+        xlim([1, image_width]);
+        ylim([1, image_height]);
+    end
+  
+    pause(0.5);
+    
+end
+

--- a/read_ensemble_direction.m
+++ b/read_ensemble_direction.m
@@ -1,0 +1,31 @@
+function ensemble_domain_string = read_ensemble_direction(JOBFILE, PASS_NUMBER)
+
+% Default to pass number of 1
+if nargin < 2
+    PASS_NUMBER = 1;
+end
+
+% Default to "no ensemble"
+ensemble_domain_string = 'none';
+
+% Check if the fields exist.
+if isfield(JOBFILE.Processing(PASS_NUMBER).Correlation, 'Ensemble')
+    
+    % Extract the ensemble field
+    ensemble_field = JOBFILE.Processing(PASS_NUMBER).Correlation.Ensemble;
+    
+    % Check if the "direction" field is specified.
+    if isfield(ensemble_field, 'Direction')
+        
+        % If the field exists, make sure it doesn't 
+        % contain an emptry string.
+        if ~isempty(ensemble_field.Direction)
+            % Read the ensemble domain
+            ensemble_domain_string = ...
+                lower(JOBFILE.Processing(PASS_NUMBER).Correlation.Ensemble.Direction);
+        end
+    end
+end
+
+
+end

--- a/run_correlation_pass.m
+++ b/run_correlation_pass.m
@@ -81,9 +81,6 @@ num_pairs_correlate = read_num_pairs(JOBFILE, PASS_NUMBER);
 % Region sizes
 [region_height, region_width] = get_region_size(JOBFILE, PASS_NUMBER);
 
-% Subpixel weights
-sub_pixel_weights = ones(region_height, region_width);
-
 % Determine if deform is requested
 iterative_method = JOBFILE.Processing(1).Iterative.Method;
 
@@ -95,19 +92,6 @@ deform_requested = ~isempty(regexpi(iterative_method, 'def'));
 % Estimated particle diameter
 particle_diameter = JOBFILE.Processing(PASS_NUMBER). ...
     SubPixel.EstimatedParticleDiameter;
-%
-% Make the particle diameters a list
-% because the adaptive methods
-% can have a different effective
-% particle diameter for each window.
-%
-% Also, there are separate diameters
-% in X and Y to allow asymmetric
-% (elliptical) particle shapes. 
-particle_diameter_list_x = particle_diameter .* ...
-    ones(num_regions_correlate, 1);
-particle_diameter_list_y = particle_diameter .* ...
-    ones(num_regions_correlate, 1);
 
 % Make some filters. 
 % These are to let the parfor loops run
@@ -447,8 +431,8 @@ for n = 1 : num_pairs_correlate
         
         % Add the measured displacements to the 
         % temporary array of displacements.
-        ty_temp(grid_inds, n) = ty;
-        tx_temp(grid_inds, n) = tx;
+        ty_temp(grid_indices, n) = ty;
+        tx_temp(grid_indices, n) = tx;
     end
     
     % Print a carriage return after
@@ -477,8 +461,8 @@ if do_temporal_ensemble
     % the results of this pass
     % even if the ensemble methods
     % are different.
-    ty_temp(grid_inds, :) = ty;
-    tx_temp(grid_inds, :) = tx;
+    ty_temp(grid_indices, :) = repmat(ty, [1, num_pairs_correlate]);
+    tx_temp(grid_indices, :) = repmat(tx, [1, num_pairs_correlate]);
 end
 
 % Allocate the "output" vectors
@@ -582,7 +566,7 @@ if do_smoothing == true
     % Loop over all the pairs.
     for n = 1 : num_pairs_correlate
         tx_full_input = tx_full_output(:, n);
-        ty_full_input = tx_full_output(:, n);
+        ty_full_input = ty_full_output(:, n);
         
         % Calculate smoothed field
         tx_smoothed_full = smoothField(tx_full_input, smoothing_kernel_diameter, smoothing_kernel_std);

--- a/save_piv_jobfile_results.m
+++ b/save_piv_jobfile_results.m
@@ -62,6 +62,9 @@ function output_file_path = save_piv_jobfile_results(JOBFILE)
 % Determine the output file path
 output_file_path = determine_jobfile_save_path(JOBFILE);
 
+% Copy the save-file path to the jobfile
+JOBFILE.Data.Outputs.Vectors.Path = output_file_path;
+
 % Copy the job file
 JobFile = JOBFILE;
 


### PR DESCRIPTION
This merge adds two main features:  time-resolved PIV and spatial ensemble correlations. I tried to make these different paradigms all compatible with each other from a multi-pass standpoint by doing the following: All displacement results arrays are in the form [M x N] where M is the number of grid points and N is the number of pairs that were correlated. If neither spatial nor temporal ensemble were performed, then all M*N elements may be unique. If temporal ensemble was performed, then all of the N columns are identical. If spatial ensemble was performed, then all of the M rows are identical. 